### PR TITLE
Add hex string initializer to LCHColor

### DIFF
--- a/Sources/ColorTokensKit/ColorSpace/LCH/LCHColor.swift
+++ b/Sources/ColorTokensKit/ColorSpace/LCH/LCHColor.swift
@@ -67,4 +67,10 @@ public struct LCHColor: Hashable, Equatable {
 
         alpha = 1.0
     }
+    
+    /// Initialize a LCHColor from a hex string. 
+    public init(hex: String) {
+        let color = Color(hex: hex)
+        self.init(color: color)
+    }
 }


### PR DESCRIPTION
Introduces a new initializer to LCHColor that allows creating an instance from a hex string, improving convenience when working with color values in hex format.