### PR TITLE
Fix watchOS compilation errors

### DIFF
--- a/Sources/ColorTokensKit/Platform/SwiftUI/Color+Dynamic.swift
+++ b/Sources/ColorTokensKit/Platform/SwiftUI/Color+Dynamic.swift
@@ -9,32 +9,42 @@ import SwiftUI
 import AppKit
 fileprivate typealias NSorUIColor = NSColor
 
-#elseif canImport(UIKit)
+#elseif canImport(UIKit) && !os(watchOS)
 import UIKit
 fileprivate typealias NSorUIColor = UIColor
 
 #endif
 
 public extension Color {
-    /// Initialize with light/dark mode colors for iOS
+    /// Initialize with light/dark mode colors
     init(
         light lightModeColor: @escaping @autoclosure () -> Color,
         dark darkModeColor: @escaping @autoclosure () -> Color
     ) {
+        #if os(watchOS)
+        // watchOS always uses dark appearance
+        self = darkModeColor()
+        #else
         self.init(NSorUIColor(
             light: NSorUIColor(lightModeColor()),
             dark: NSorUIColor(darkModeColor())
         ))
+        #endif
     }
 
-    /// Initialize with light/dark mode LCH colors for iOS
+    /// Initialize with light/dark mode LCH colors
     init(
         light lightModeColor: @escaping @autoclosure () -> LCHColor,
         dark darkModeColor: @escaping @autoclosure () -> LCHColor
     ) {
+        #if os(watchOS)
+        // watchOS always uses dark appearance
+        self = darkModeColor().toColor()
+        #else
         self.init(NSorUIColor(
             light: NSorUIColor(lightModeColor().toColor()),
             dark: NSorUIColor(darkModeColor().toColor())
         ))
+        #endif
     }
 }

--- a/Sources/ColorTokensKit/Platform/UIKit/UIColor+Dynamic.swift
+++ b/Sources/ColorTokensKit/Platform/UIKit/UIColor+Dynamic.swift
@@ -3,7 +3,7 @@
 //  ColorTokensKit
 //
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
     import UIKit
 
     public extension UIColor {


### PR DESCRIPTION
## Summary
- Excludes `UIColor+Dynamic.swift` from watchOS builds by adding `!os(watchOS)` to the `#if canImport(UIKit)` guard, since `UIColor(dynamicProvider:)` and `userInterfaceStyle` are unavailable on watchOS
- Adds watchOS-specific paths in `Color+Dynamic.swift` that default to the dark mode color, since watchOS always uses a dark appearance
- Verified builds pass on watchOS, iOS, and macOS

## Test plan
- [x] `swift build` for watchOS simulator — passes
- [x] `swift build` for iOS simulator — passes
- [x] `swift build` for macOS — passes

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)