### PR TITLE
Lower deployment targets to iOS 16, macOS 13, tvOS 16, watchOS 9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
     name: "ColorTokensKit",
     platforms: [
-        .iOS(.v17),
-        .macOS(.v14),
-        .tvOS(.v17),
-        .watchOS(.v10),
+        .iOS(.v16),
+        .macOS(.v13),
+        .tvOS(.v16),
+        .watchOS(.v9),
         .visionOS(.v1),
     ],
     products: [

--- a/Sources/ColorTokensKit/ColorSpace/RGB/RGBColor.swift
+++ b/Sources/ColorTokensKit/ColorSpace/RGB/RGBColor.swift
@@ -21,7 +21,7 @@ public struct RGBColor: Hashable {
     }
 
     public init(color: Color) {
-        if #available(iOS 17.0, *) {
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
             let resolvedColor = color.resolve(in: .init())
             self.r = CGFloat(resolvedColor.red)
             self.g = CGFloat(resolvedColor.green)

--- a/Sources/ColorTokensKit/Platform/SwiftUI/Color+Strings.swift
+++ b/Sources/ColorTokensKit/Platform/SwiftUI/Color+Strings.swift
@@ -11,30 +11,17 @@ public extension Color {
 
     /// Converts the `LCHColor` to a hexadecimal string representation.
     func getHexString() -> String {
-        let resolvedColor = resolve(in: .init())
+        let rgb = RGBColor(color: self)
+        let r = Double(max(0, min(rgb.r, 1)))
+        let g = Double(max(0, min(rgb.g, 1)))
+        let b = Double(max(0, min(rgb.b, 1)))
+        let a = Double(max(0, min(rgb.alpha, 1)))
 
-        // Ensure RGB values are within [0, 1]
-        let r = Double(max(0, min(resolvedColor.red, 1)))
-        let g = Double(max(0, min(resolvedColor.green, 1)))
-        let b = Double(max(0, min(resolvedColor.blue, 1)))
-        let a = Double(max(0, min(resolvedColor.cgColor.alpha, 1)))
-
-        // Convert to hexadecimal
-        let hexString: String
         if a != 1.0 {
-            hexString = String(format: "%02lX%02lX%02lX%02lX", lround(r * 255), lround(g * 255), lround(b * 255), lround(a * 255))
+            return String(format: "%02lX%02lX%02lX%02lX", lround(r * 255), lround(g * 255), lround(b * 255), lround(a * 255))
         } else {
-            hexString = String(format: "%02lX%02lX%02lX", lround(r * 255), lround(g * 255), lround(b * 255))
+            return String(format: "%02lX%02lX%02lX", lround(r * 255), lround(g * 255), lround(b * 255))
         }
-
-        print("red \(r)")
-        print("green \(g)")
-        print("blue \(b)")
-        print("alpha \(a)")
-        print("hex: \(hexString)")
-        print("-------")
-
-        return hexString
     }
     
     /// Get LCH string representation


### PR DESCRIPTION
## Summary
- Lowers minimum deployment targets: iOS 17→16, macOS 14→13, tvOS 17→16, watchOS 10→9
- Refactors `Color.getHexString()` to reuse `RGBColor` (which already has proper `#available` fallbacks) instead of calling `resolve(in:)` directly — that API requires iOS 17+/macOS 14+
- Fixes the `#available` check in `RGBColor.init(color:)` to include explicit `macOS 14.0, tvOS 17.0, watchOS 10.0` guards (was only checking `iOS 17.0`)

## Test plan
- [x] `swift build` for macOS — passes
- [x] `swift build` for iOS simulator — passes
- [x] `swift build` for watchOS simulator — passes

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)