### PR TITLE
Fix Xcode 26.4 build error: unify rounded(to:) method name on Double

### DIFF
--- a/Sources/ColorTokensKit/Services/Ramps/ColorRampGenerator.swift
+++ b/Sources/ColorTokensKit/Services/Ramps/ColorRampGenerator.swift
@@ -193,11 +193,11 @@ public class ColorRampGenerator {
     /// - Returns: Interpolated value
     private func lerp(_ a: Double, _ b: Double, _ t: Double) -> Double {
         // Normalize t to ensure consistent results
-        let normalizedT = t.rounded(toPlaces: ColorConstants.interpolationPrecision)
+        let normalizedT = t.rounded(to: ColorConstants.interpolationPrecision)
         let result = a + ((b - a) * normalizedT)
         
         // Round to specified decimal places for consistency
-        return result.rounded(toPlaces: ColorConstants.valuePrecision)
+        return result.rounded(to: ColorConstants.valuePrecision)
     }
 
     /// Interpolates between two hue angles, taking the shortest path around the color wheel
@@ -210,7 +210,7 @@ public class ColorRampGenerator {
         // Normalize inputs to ensure consistent results
         let normalizedH1 = h1.normalizedHue
         let normalizedH2 = h2.normalizedHue
-        let normalizedT = t.rounded(toPlaces: ColorConstants.interpolationPrecision)
+        let normalizedT = t.rounded(to: ColorConstants.interpolationPrecision)
         
         let diff = (normalizedH2 - normalizedH1 + 360).normalizedHue
         let shortestPath = diff <= 180 ? diff : diff - 360

--- a/Sources/ColorTokensKit/Utils/Double+Ext.swift
+++ b/Sources/ColorTokensKit/Utils/Double+Ext.swift
@@ -12,13 +12,13 @@ public extension Double {
         // First ensure the value is in the 0-360 range
         let normalized = (self.truncatingRemainder(dividingBy: 360) + 360).truncatingRemainder(dividingBy: 360)
         // Then round to specified decimal places for consistency
-        return normalized.rounded(toPlaces: ColorConstants.huePrecision)
+        return normalized.rounded(to: ColorConstants.huePrecision)
     }
-    
+
     /// Rounds a value to a specific number of decimal places
     /// - Parameter places: Number of decimal places to round to
     /// - Returns: Rounded value
-    func rounded(toPlaces places: Int) -> Double {
+    func rounded(to places: Int) -> Double {
         let multiplier = pow(10.0, Double(places))
         return (self * multiplier).rounded() / multiplier
     }


### PR DESCRIPTION
## Summary

- `Double+Ext.swift` defined `rounded(toPlaces:)` while `CGFloat+Ext.swift` defined `rounded(to:)` — inconsistent labels
- Xcode 26.4 strictly infers arithmetic results (like `rawT`) as `Double`, so call sites using `rounded(to:)` on a `Double` failed to compile
- Renames `Double.rounded(toPlaces:)` → `rounded(to:)` and updates the 3 call sites in `ColorRampGenerator.swift`

Closes #22 (addresses the same issue reported by @talesp — thanks for the report!)

## Test plan

- [x] `swift build` passes cleanly
- [x] `swift test` passes (1 test, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)