### PR TITLE
Add comprehensive test suite and improvement roadmap

### DIFF
--- a/Tests/ColorTokensKitTests/ColorRampTests.swift
+++ b/Tests/ColorTokensKitTests/ColorRampTests.swift
@@ -1,0 +1,150 @@
+@testable import ColorTokensKit
+import XCTest
+
+final class ColorRampTests: XCTestCase {
+
+    // MARK: - Ramp Generation
+
+    func testRampGeneratesCorrectNumberOfStops() {
+        let generator = ColorRampGenerator()
+        let ramp = generator.getColorRamp(forHue: 210)
+        XCTAssertEqual(ramp.count, ColorConstants.rampStops,
+                       "Default ramp should have \(ColorConstants.rampStops) stops, got \(ramp.count)")
+    }
+
+    func testRampLightnessDecreases() {
+        let generator = ColorRampGenerator()
+        let ramp = generator.getColorRamp(forHue: 210)
+
+        // Ramp should go from light to dark (decreasing L)
+        for i in 0..<(ramp.count - 1) {
+            XCTAssertGreaterThanOrEqual(ramp[i].l, ramp[i + 1].l,
+                "Lightness should decrease monotonically: stop \(i) (L=\(ramp[i].l)) should be >= stop \(i+1) (L=\(ramp[i+1].l))")
+        }
+    }
+
+    func testRampFirstStopIsLight() {
+        let generator = ColorRampGenerator()
+        let ramp = generator.getColorRamp(forHue: 210)
+        XCTAssertGreaterThan(ramp.first!.l, 80,
+                             "First ramp stop should be very light, got L=\(ramp.first!.l)")
+    }
+
+    func testRampLastStopIsDark() {
+        let generator = ColorRampGenerator()
+        let ramp = generator.getColorRamp(forHue: 210)
+        XCTAssertLessThan(ramp.last!.l, 20,
+                          "Last ramp stop should be very dark, got L=\(ramp.last!.l)")
+    }
+
+    func testGrayscaleRampHasLowChroma() {
+        let generator = ColorRampGenerator()
+        let ramp = generator.getColorRamp(forHue: 0, isGrayscale: true)
+        for (i, color) in ramp.enumerated() {
+            XCTAssertLessThan(color.c, 1.0,
+                "Grayscale ramp stop \(i) should have near-zero chroma, got C=\(color.c)")
+        }
+    }
+
+    // MARK: - Ramp Determinism
+
+    func testRampIsDeterministic() {
+        let generator = ColorRampGenerator()
+        let ramp1 = generator.getColorRamp(forHue: 140)
+        let ramp2 = generator.getColorRamp(forHue: 140)
+        XCTAssertEqual(ramp1.count, ramp2.count)
+        for i in 0..<ramp1.count {
+            XCTAssertEqual(ramp1[i].l, ramp2[i].l, accuracy: 0.001,
+                           "Ramp should be deterministic at stop \(i)")
+            XCTAssertEqual(ramp1[i].c, ramp2[i].c, accuracy: 0.001)
+            XCTAssertEqual(ramp1[i].h, ramp2[i].h, accuracy: 0.001)
+        }
+    }
+
+    func testDifferentHuesProduceDifferentRamps() {
+        let generator = ColorRampGenerator()
+        let blueRamp = generator.getColorRamp(forHue: 210)
+        let redRamp = generator.getColorRamp(forHue: 10)
+
+        // Midpoint colors should have different hues
+        let blueMiddle = blueRamp[blueRamp.count / 2]
+        let redMiddle = redRamp[redRamp.count / 2]
+        XCTAssertNotEqual(blueMiddle.h, redMiddle.h, "Blue and red ramps should have different hues")
+    }
+
+    // MARK: - Named Stops API
+
+    func testNamedStopsAccessors() {
+        let color = LCHColor(l: 50, c: 30, h: 210)
+        let first = color._50
+        let last = color._1000
+
+        XCTAssertGreaterThan(first.l, last.l,
+                             "_50 should be lighter than _1000")
+    }
+
+    func testAllStopsReturns20Colors() {
+        let color = LCHColor(l: 50, c: 30, h: 210)
+        let stops = color.allStops
+        XCTAssertEqual(stops.count, 20, "allStops should return 20 colors")
+    }
+
+    // MARK: - Pro Colors
+
+    func testProColorsAreDistinct() {
+        let hues = Color.allProHues
+        XCTAssertGreaterThan(hues.count, 20, "Should have 20+ pro colors")
+
+        // Each color should have unique L/C/H values
+        var seen = Set<LCHColor>()
+        for (name, color) in hues {
+            XCTAssertFalse(seen.contains(color), "Pro color '\(name)' is a duplicate")
+            seen.insert(color)
+        }
+    }
+
+    func testProGrayIsLowChroma() {
+        let gray = Color.proGray
+        XCTAssertLessThan(gray.c, 5, "proGray should have very low chroma, got \(gray.c)")
+    }
+
+    func testProBlueHasBlueHue() {
+        let blue = Color.proBlue
+        // Blue hue in LCH is roughly 250-280
+        XCTAssertGreaterThan(blue.h, 200, "proBlue hue should be in blue range, got \(blue.h)")
+        XCTAssertLessThan(blue.h, 290, "proBlue hue should be in blue range, got \(blue.h)")
+    }
+
+    // MARK: - Edge Cases
+
+    func testRampAtHueZeroAndHue360AreEquivalent() {
+        let generator = ColorRampGenerator()
+        let ramp0 = generator.getColorRamp(forHue: 0)
+        let ramp360 = generator.getColorRamp(forHue: 360)
+        XCTAssertEqual(ramp0.count, ramp360.count)
+        for i in 0..<ramp0.count {
+            XCTAssertEqual(ramp0[i].l, ramp360[i].l, accuracy: 0.01,
+                "Hue 0 and 360 should produce identical ramps at stop \(i)")
+            XCTAssertEqual(ramp0[i].c, ramp360[i].c, accuracy: 0.01)
+            XCTAssertEqual(ramp0[i].h, ramp360[i].h, accuracy: 0.01)
+        }
+    }
+
+    func testRampAtArbitraryHue() {
+        // Hue between two palette entries should still produce valid ramp
+        let generator = ColorRampGenerator()
+        let ramp = generator.getColorRamp(forHue: 173.5)
+        XCTAssertEqual(ramp.count, ColorConstants.rampStops)
+        for (i, color) in ramp.enumerated() {
+            XCTAssertTrue(color.l >= 0 && color.l <= 100,
+                "Stop \(i) lightness \(color.l) should be in [0, 100]")
+            XCTAssertTrue(color.c >= 0,
+                "Stop \(i) chroma \(color.c) should be non-negative")
+            XCTAssertTrue(color.h >= 0 && color.h < 360,
+                "Stop \(i) hue \(color.h) should be in [0, 360)")
+        }
+    }
+}
+
+// Access Color.proBlue etc. which are defined as returning LCHColor
+import SwiftUI

--- a/Tests/ColorTokensKitTests/ColorSpaceTests.swift
+++ b/Tests/ColorTokensKitTests/ColorSpaceTests.swift
@@ -1,0 +1,167 @@
+@testable import ColorTokensKit
+import XCTest
+
+final class ColorSpaceConversionTests: XCTestCase {
+
+    let tolerance: CGFloat = 0.01 // Allow small floating-point drift
+
+    // MARK: - Known Reference Colors (from CIE standards / online converters)
+
+    // sRGB pure red (1, 0, 0) -> XYZ (0.4124, 0.2127, 0.0193) -> LAB (53.23, 80.11, 67.22) -> LCH (53.23, 104.55, ~40°)
+    func testRedRGBToXYZ() {
+        let red = RGBColor(r: 1, g: 0, b: 0, alpha: 1)
+        let xyz = red.toXYZ()
+        XCTAssertEqual(xyz.x, 0.4124, accuracy: tolerance)
+        XCTAssertEqual(xyz.y, 0.2127, accuracy: tolerance)
+        XCTAssertEqual(xyz.z, 0.0193, accuracy: tolerance)
+    }
+
+    func testRedRGBToLAB() {
+        let red = RGBColor(r: 1, g: 0, b: 0, alpha: 1)
+        let lab = red.toLAB()
+        XCTAssertEqual(lab.l, 53.23, accuracy: 0.1)
+        XCTAssertEqual(lab.a, 80.11, accuracy: 0.2)
+        XCTAssertEqual(lab.b, 67.22, accuracy: 0.2)
+    }
+
+    func testRedRGBToLCH() {
+        let red = RGBColor(r: 1, g: 0, b: 0, alpha: 1)
+        let lch = red.toLCH()
+        XCTAssertEqual(lch.l, 53.23, accuracy: 0.2)
+        XCTAssertTrue(lch.c > 100, "Red should have high chroma, got \(lch.c)")
+        XCTAssertEqual(lch.h, 40.0, accuracy: 1.0) // Hue around 40° for red
+    }
+
+    // sRGB pure green (0, 1, 0) -> LAB (87.74, -86.18, 83.18)
+    func testGreenRGBToLAB() {
+        let green = RGBColor(r: 0, g: 1, b: 0, alpha: 1)
+        let lab = green.toLAB()
+        XCTAssertEqual(lab.l, 87.74, accuracy: 0.2)
+        XCTAssertEqual(lab.a, -86.18, accuracy: 0.3)
+        XCTAssertEqual(lab.b, 83.18, accuracy: 0.3)
+    }
+
+    // sRGB pure blue (0, 0, 1) -> LAB (32.30, 79.20, -107.86)
+    func testBlueRGBToLAB() {
+        let blue = RGBColor(r: 0, g: 0, b: 1, alpha: 1)
+        let lab = blue.toLAB()
+        XCTAssertEqual(lab.l, 32.30, accuracy: 0.2)
+        XCTAssertEqual(lab.a, 79.20, accuracy: 0.3)
+        XCTAssertEqual(lab.b, -107.86, accuracy: 0.3)
+    }
+
+    // White (1, 1, 1) -> LAB (100, 0, 0)
+    func testWhiteRGBToLAB() {
+        let white = RGBColor(r: 1, g: 1, b: 1, alpha: 1)
+        let lab = white.toLAB()
+        XCTAssertEqual(lab.l, 100.0, accuracy: 0.1)
+        XCTAssertEqual(lab.a, 0.0, accuracy: 0.1)
+        XCTAssertEqual(lab.b, 0.0, accuracy: 0.1)
+    }
+
+    // Black (0, 0, 0) -> LAB (0, 0, 0)
+    func testBlackRGBToLAB() {
+        let black = RGBColor(r: 0, g: 0, b: 0, alpha: 1)
+        let lab = black.toLAB()
+        XCTAssertEqual(lab.l, 0.0, accuracy: 0.1)
+        XCTAssertEqual(lab.a, 0.0, accuracy: 0.1)
+        XCTAssertEqual(lab.b, 0.0, accuracy: 0.1)
+    }
+
+    // 50% gray (0.5, 0.5, 0.5) -> LAB (~53.39, 0, 0)
+    func testMidGrayRGBToLAB() {
+        let gray = RGBColor(r: 0.5, g: 0.5, b: 0.5, alpha: 1)
+        let lab = gray.toLAB()
+        XCTAssertEqual(lab.l, 53.39, accuracy: 0.2)
+        XCTAssertEqual(lab.a, 0.0, accuracy: 0.1)
+        XCTAssertEqual(lab.b, 0.0, accuracy: 0.1)
+    }
+
+    // MARK: - Round-Trip Accuracy
+
+    func testRGBRoundTripThroughLCH() {
+        let testColors: [(r: CGFloat, g: CGFloat, b: CGFloat, name: String)] = [
+            (1.0, 0.0, 0.0, "red"),
+            (0.0, 1.0, 0.0, "green"),
+            (0.0, 0.0, 1.0, "blue"),
+            (1.0, 1.0, 0.0, "yellow"),
+            (0.0, 1.0, 1.0, "cyan"),
+            (1.0, 0.0, 1.0, "magenta"),
+            (1.0, 1.0, 1.0, "white"),
+            (0.0, 0.0, 0.0, "black"),
+            (0.5, 0.5, 0.5, "gray"),
+            (0.8, 0.2, 0.6, "arbitrary"),
+        ]
+
+        for color in testColors {
+            let original = RGBColor(r: color.r, g: color.g, b: color.b, alpha: 1)
+            let roundTrip = original.toLCH().toRGB()
+            XCTAssertEqual(roundTrip.r, original.r, accuracy: tolerance,
+                           "Round-trip failed for \(color.name) R: \(roundTrip.r) vs \(original.r)")
+            XCTAssertEqual(roundTrip.g, original.g, accuracy: tolerance,
+                           "Round-trip failed for \(color.name) G: \(roundTrip.g) vs \(original.g)")
+            XCTAssertEqual(roundTrip.b, original.b, accuracy: tolerance,
+                           "Round-trip failed for \(color.name) B: \(roundTrip.b) vs \(original.b)")
+        }
+    }
+
+    // MARK: - Alpha Preservation
+
+    func testAlphaPreservedThroughConversions() {
+        let original = RGBColor(r: 0.5, g: 0.5, b: 0.5, alpha: 0.42)
+        let xyz = original.toXYZ()
+        XCTAssertEqual(xyz.alpha, 0.42, accuracy: 0.001)
+        let lab = xyz.toLAB()
+        XCTAssertEqual(lab.alpha, 0.42, accuracy: 0.001)
+        let lch = lab.toLCH()
+        XCTAssertEqual(lch.alpha, 0.42, accuracy: 0.001)
+        let backToRGB = lch.toRGB()
+        XCTAssertEqual(backToRGB.alpha, 0.42, accuracy: 0.001)
+    }
+
+    // MARK: - LCH Specific
+
+    func testLCHHueNormalization() {
+        // Negative hue should normalize to 0-360
+        let color1 = LCHColor(l: 50, c: 30, h: -30)
+        XCTAssertTrue(color1.h >= 0 && color1.h < 360,
+                       "Hue \(color1.h) should be normalized to [0, 360)")
+
+        // Hue > 360 should normalize
+        let color2 = LCHColor(l: 50, c: 30, h: 400)
+        XCTAssertTrue(color2.h >= 0 && color2.h < 360,
+                       "Hue \(color2.h) should be normalized to [0, 360)")
+
+        // Hue = 360 should become 0
+        let color3 = LCHColor(l: 50, c: 30, h: 360)
+        XCTAssertEqual(color3.h, 0.0, accuracy: 0.01)
+    }
+
+    func testLCHFromLCHString() {
+        let color = LCHColor(lchString: "lch(65% 40 210)")
+        XCTAssertEqual(color.l, 65.0, accuracy: 0.01)
+        XCTAssertEqual(color.c, 40.0, accuracy: 0.01)
+        XCTAssertEqual(color.h, 210.0, accuracy: 0.01)
+    }
+
+    func testLCHFromInvalidStringUsesDefaults() {
+        let color = LCHColor(lchString: "not a color")
+        XCTAssertEqual(color.l, 70.0, accuracy: 0.01)
+        XCTAssertEqual(color.c, 30.0, accuracy: 0.01)
+        XCTAssertEqual(color.h, 0.0, accuracy: 0.01)
+    }
+
+    func testLCHFromHexRoundTrips() {
+        let color = LCHColor(hex: "#FF0000")
+        XCTAssertEqual(color.l, 53.23, accuracy: 0.5)
+        XCTAssertTrue(color.c > 100, "Red hex should have high chroma")
+    }
+
+    func testLCHEquality() {
+        let a = LCHColor(l: 50, c: 30, h: 180)
+        let b = LCHColor(l: 50, c: 30, h: 180)
+        let c = LCHColor(l: 51, c: 30, h: 180)
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+}

--- a/Tests/ColorTokensKitTests/InterpolationTests.swift
+++ b/Tests/ColorTokensKitTests/InterpolationTests.swift
@@ -1,0 +1,107 @@
+@testable import ColorTokensKit
+import XCTest
+
+final class InterpolationTests: XCTestCase {
+
+    let tolerance: CGFloat = 0.5
+
+    // MARK: - LCH Lerp Basics
+
+    func testLerpAtZeroReturnsStart() {
+        let a = LCHColor(l: 30, c: 40, h: 100)
+        let b = LCHColor(l: 70, c: 80, h: 200)
+        let result = a.lerp(b, t: 0)
+        XCTAssertEqual(result.l, 30, accuracy: tolerance)
+        XCTAssertEqual(result.c, 40, accuracy: tolerance)
+        XCTAssertEqual(result.h, 100, accuracy: tolerance)
+    }
+
+    func testLerpAtOneReturnsEnd() {
+        let a = LCHColor(l: 30, c: 40, h: 100)
+        let b = LCHColor(l: 70, c: 80, h: 200)
+        let result = a.lerp(b, t: 1)
+        XCTAssertEqual(result.l, 70, accuracy: tolerance)
+        XCTAssertEqual(result.c, 80, accuracy: tolerance)
+        XCTAssertEqual(result.h, 200, accuracy: tolerance)
+    }
+
+    func testLerpAtHalfReturnsMidpoint() {
+        let a = LCHColor(l: 20, c: 40, h: 100)
+        let b = LCHColor(l: 80, c: 80, h: 200)
+        let result = a.lerp(b, t: 0.5)
+        XCTAssertEqual(result.l, 50, accuracy: tolerance)
+        XCTAssertEqual(result.c, 60, accuracy: tolerance)
+        XCTAssertEqual(result.h, 150, accuracy: tolerance)
+    }
+
+    // MARK: - Hue Wrapping (shortest path)
+
+    func testLerpHueShortestPathForward() {
+        // 10 -> 350: shortest path is backwards (-20), not forward (+340)
+        let a = LCHColor(l: 50, c: 50, h: 10)
+        let b = LCHColor(l: 50, c: 50, h: 350)
+        let result = a.lerp(b, t: 0.5)
+        // Midpoint should be at 0/360, not at 180
+        let hue = result.h
+        XCTAssertTrue(hue < 10 || hue > 350,
+                       "Midpoint hue between 10 and 350 should wrap around 0, got \(hue)")
+    }
+
+    func testLerpHueShortestPathBackward() {
+        // 350 -> 10: shortest path is forward (+20)
+        let a = LCHColor(l: 50, c: 50, h: 350)
+        let b = LCHColor(l: 50, c: 50, h: 10)
+        let result = a.lerp(b, t: 0.5)
+        let hue = result.h
+        XCTAssertTrue(hue < 10 || hue > 350,
+                       "Midpoint hue between 350 and 10 should wrap around 0, got \(hue)")
+    }
+
+    func testLerpHueSameValue() {
+        let a = LCHColor(l: 50, c: 50, h: 180)
+        let b = LCHColor(l: 50, c: 50, h: 180)
+        let result = a.lerp(b, t: 0.5)
+        XCTAssertEqual(result.h, 180, accuracy: 0.1)
+    }
+
+    func testLerpHueOppositeValues() {
+        // 0 -> 180: exactly opposite, either direction is valid
+        let a = LCHColor(l: 50, c: 50, h: 0)
+        let b = LCHColor(l: 50, c: 50, h: 180)
+        let result = a.lerp(b, t: 0.5)
+        // Should be 90 or 270 depending on direction chosen
+        XCTAssertTrue(
+            abs(result.h - 90) < tolerance || abs(result.h - 270) < tolerance,
+            "Midpoint between 0 and 180 should be 90 or 270, got \(result.h)"
+        )
+    }
+
+    // MARK: - Alpha Interpolation
+
+    func testLerpInterpolatesAlpha() {
+        let a = LCHColor(l: 50, c: 50, h: 100, alpha: 0.0)
+        let b = LCHColor(l: 50, c: 50, h: 100, alpha: 1.0)
+        let result = a.lerp(b, t: 0.5)
+        XCTAssertEqual(result.alpha, 0.5, accuracy: 0.01)
+    }
+
+    // MARK: - RGB/LAB/XYZ Interpolation
+
+    func testRGBLerp() {
+        let a = RGBColor(r: 0, g: 0, b: 0, alpha: 1)
+        let b = RGBColor(r: 1, g: 1, b: 1, alpha: 1)
+        let mid = a.lerp(b, t: 0.5)
+        XCTAssertEqual(mid.r, 0.5, accuracy: 0.01)
+        XCTAssertEqual(mid.g, 0.5, accuracy: 0.01)
+        XCTAssertEqual(mid.b, 0.5, accuracy: 0.01)
+    }
+
+    func testLABLerp() {
+        let a = LABColor(l: 0, a: -50, b: -50, alpha: 1)
+        let b = LABColor(l: 100, a: 50, b: 50, alpha: 1)
+        let mid = a.lerp(b, t: 0.5)
+        XCTAssertEqual(mid.l, 50, accuracy: 0.01)
+        XCTAssertEqual(mid.a, 0, accuracy: 0.01)
+        XCTAssertEqual(mid.b, 0, accuracy: 0.01)
+    }
+}

--- a/Tests/ColorTokensKitTests/UtilityTests.swift
+++ b/Tests/ColorTokensKitTests/UtilityTests.swift
@@ -1,0 +1,69 @@
+@testable import ColorTokensKit
+import XCTest
+
+final class UtilityTests: XCTestCase {
+
+    // MARK: - Double.normalizedHue
+
+    func testNormalizedHuePositive() {
+        XCTAssertEqual(Double(90).normalizedHue, 90.0, accuracy: 0.01)
+        XCTAssertEqual(Double(359).normalizedHue, 359.0, accuracy: 0.01)
+    }
+
+    func testNormalizedHueNegative() {
+        XCTAssertEqual(Double(-10).normalizedHue, 350.0, accuracy: 0.01)
+        XCTAssertEqual(Double(-360).normalizedHue, 0.0, accuracy: 0.01)
+        XCTAssertEqual(Double(-90).normalizedHue, 270.0, accuracy: 0.01)
+    }
+
+    func testNormalizedHueOverflow() {
+        XCTAssertEqual(Double(370).normalizedHue, 10.0, accuracy: 0.01)
+        XCTAssertEqual(Double(720).normalizedHue, 0.0, accuracy: 0.01)
+        XCTAssertEqual(Double(810).normalizedHue, 90.0, accuracy: 0.01)
+    }
+
+    func testNormalizedHueZero() {
+        XCTAssertEqual(Double(0).normalizedHue, 0.0, accuracy: 0.01)
+    }
+
+    func testNormalizedHue360() {
+        XCTAssertEqual(Double(360).normalizedHue, 0.0, accuracy: 0.01)
+    }
+
+    // MARK: - Double.rounded(to:)
+
+    func testRoundedToPlaces() {
+        XCTAssertEqual(Double(3.14159).rounded(to: 2), 3.14, accuracy: 0.001)
+        XCTAssertEqual(Double(3.14159).rounded(to: 4), 3.1416, accuracy: 0.00001)
+        XCTAssertEqual(Double(3.14159).rounded(to: 0), 3.0, accuracy: 0.001)
+    }
+
+    // MARK: - CGFloat.rounded(to:)
+
+    func testCGFloatRoundedToPlaces() {
+        XCTAssertEqual(CGFloat(2.71828).rounded(to: 2), 2.72, accuracy: 0.001)
+        XCTAssertEqual(CGFloat(2.71828).rounded(to: 3), 2.718, accuracy: 0.0001)
+    }
+
+    // MARK: - Double and CGFloat consistency
+
+    func testDoubleAndCGFloatNormalizedHueMatch() {
+        let testValues: [Double] = [-90, 0, 45, 180, 359.5, 400, 720]
+        for value in testValues {
+            let doubleResult = value.normalizedHue
+            let cgfloatResult = CGFloat(value).normalizedHue
+            XCTAssertEqual(doubleResult, Double(cgfloatResult), accuracy: 0.01,
+                "normalizedHue should match for Double and CGFloat at value \(value)")
+        }
+    }
+
+    func testDoubleAndCGFloatRoundedToMatch() {
+        let testValues: [Double] = [3.14159, 0.0, -2.718, 100.555]
+        for value in testValues {
+            let doubleResult = value.rounded(to: 2)
+            let cgfloatResult = CGFloat(value).rounded(to: 2)
+            XCTAssertEqual(doubleResult, Double(cgfloatResult), accuracy: 0.001,
+                "rounded(to:) should match for Double and CGFloat at value \(value)")
+        }
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,138 @@
+# ColorTokensKit Critique & Improvement Roadmap
+
+## Context
+
+ColorTokensKit is an LCH-based color token library for Apple platforms. After a thorough code review and comparison with industry-leading libraries (culori, chroma.js, Color.js, Radix Colors, Tailwind v4, Adobe Leonardo), we've identified gaps ranging from correctness issues to missing table-stakes features. The library's core math is sound, but it lags behind the ecosystem in gamut handling, accessibility, modern color science (OKLCH), test coverage, and performance.
+
+Below is a prioritized breakdown from most important to least important.
+
+---
+
+## Critical (fix now)
+
+### 1. Zero test coverage
+- The only test (`MarketingTests.swift`) generates marketing PNGs — no actual assertions
+- No round-trip conversion accuracy tests (RGB -> XYZ -> LAB -> LCH -> LAB -> XYZ -> RGB)
+- No interpolation tests (hue wrapping at 359->1, edge cases)
+- No ramp generation determinism tests
+- **Why it matters:** Every other issue on this list could silently regress without tests
+- **Action:** Add test suites for conversions, interpolation, ramp generation, and edge cases
+
+### 2. No gamut clamping
+- `RGBColor` stores raw CGFloat values with no clamping to [0, 1]
+- High-chroma LCH colors (saturated yellows, cyans) produce negative or >1 RGB values
+- SwiftUI may silently clamp, causing uncontrolled hue shifts and lightness distortion
+- **Files:** `XYZColor+Conversions.swift` (toRGB output), `RGBColor.swift`
+- **Action:** At minimum, clamp RGB output to [0, 1]. Ideally, implement chroma reduction that preserves hue (reduce chroma until in-gamut)
+
+### 3. ColorRampGenerator performance — new instance on every stop access
+- `LCHColor.getColor(at:)` creates a new `ColorRampGenerator()` on every call
+- Accessing `_50` through `_1000` (20 stops) = 20 instances created
+- `getPrimaryColor(forHue:)` has the same issue
+- **Files:** `LCHColor+Manipulation.swift` lines 28-34, 37-49
+- **Action:** Make `ColorRampGenerator` a singleton or use a shared static instance
+
+### 4. Thread safety on static cache
+- `ColorRampGenerator.interpolatedRamps` is a static `[String: [LCHColor]]` with no synchronization
+- Race condition if accessed from multiple threads (e.g., SwiftUI background rendering)
+- **File:** `ColorRampGenerator.swift` lines 20-21
+- **Action:** Use `NSLock`, `DispatchQueue`, or make the cache an actor
+
+---
+
+## High (address soon)
+
+### 5. Add WCAG contrast ratio utility
+- Every major color library provides this — it's table stakes for a design token library
+- Simple formula: relative luminance from sRGB, then `(L1 + 0.05) / (L2 + 0.05)`
+- Companies like Linear, Stripe, Slack all use contrast-based token selection
+- **Action:** Add `contrastRatio(with:)` on `LCHColor` and/or `Color`
+
+### 6. Consider OKLCH support
+- CIELab has known hue linearity problems — blue hues (270-330 degrees) shift toward purple when chroma changes
+- OKLCH fixes this; it's now the standard in CSS Color Level 4, Tailwind v4, and modern design tools
+- Not necessarily a replacement (CIELab is still valid), but offering OKLCH as an option would modernize the library significantly
+- **Action:** Add `OKLABColor` and `OKLCHColor` types with conversions. Could be a follow-up release
+
+### 7. Rounding accumulation in ramp generation
+- Rounding to 2-3 decimal places happens at multiple stages in `ColorRampGenerator`:
+  - Hue angles (2 dp), interpolation t (3 dp), lerp results (2 dp), progress values (4 dp)
+- Cumulative rounding can cause visible banding in subtle color transitions
+- **Action:** Defer rounding to the final output step only, use full precision internally
+
+### 8. Sendable conformance
+- None of the color types (RGBColor, LABColor, XYZColor, LCHColor) conform to `Sendable`
+- These are immutable value types — conformance is trivial and enables safe async/await usage
+- **Action:** Add `: Sendable` to all four color space structs
+
+---
+
+## Medium (improve when touching these areas)
+
+### 9. Add Delta E (color difference) API
+- Standard perceptual color difference metric (CIE76 is simplest: Euclidean distance in Lab)
+- CIEDE2000 is the gold standard but complex — CIE76 is a good starting point
+- Useful for: color matching, deduplication, testing ramp uniformity
+- **Action:** Add `deltaE(to:)` on `LABColor` and `LCHColor`
+
+### 10. Non-linear lightness curves in ramp generation
+- Linear interpolation in LCH produces mathematically even steps but perceptually uneven ramps
+- Industry approach: lighter shades need faster falloff, midtones compress for vibrancy, dark stops shift saturation
+- chroma.js offers `correctLightness()`; Tailwind hand-tunes curves; Leonardo targets contrast ratios
+- **Action:** Allow optional easing/curve function parameter in ramp generation
+
+### 11. Semantic token layer
+- Current system: primitive stops (`_50` to `_1000`) + ad-hoc tokens in test target
+- Mature systems use 3 tiers: Primitive (blue-500) -> Semantic (color-bg-primary) -> Component (button-bg)
+- Radix uses 12 steps with defined purposes (app bg, subtle bg, UI element, borders, solid, text)
+- **Action:** Promote the token definitions from test target to the main library, with a structured API
+
+### 12. Error handling improvements
+- `ColorRampGenerator.init()` calls `fatalError` if palette JSON fails to load
+- `LCHColor.init(lchString:)` uses `try!` on NSRegularExpression
+- **Action:** Use throwing init or provide fallback colors instead of crashing
+
+---
+
+## Low (nice to have)
+
+### 13. Code deduplication — interpolation pattern
+- `lerp()` is copy-pasted identically across RGB, LAB, XYZ interpolation extensions
+- Could unify via a protocol like `Interpolatable`
+- **Impact:** Maintainability, not functionality
+
+### 14. Additional color space support
+- HSL/HSV conversions (common user request)
+- Display P3 gamut awareness (relevant for modern Apple devices)
+
+### 15. Color blindness simulation
+- Brettel/Vienot algorithms for protanopia, deuteranopia, tritanopia
+- Increasingly expected in accessibility-focused libraries
+
+### 16. Documentation
+- No inline docs on conversion math
+- No references to CIE standards or academic sources
+- No design rationale (why 20 stops? why D65? why these precision constants?)
+
+---
+
+## Summary table
+
+| # | Issue | Severity | Effort |
+|---|-------|----------|--------|
+| 1 | Test coverage | Critical | Large |
+| 2 | Gamut clamping | Critical | Small |
+| 3 | Ramp generator performance | Critical | Small |
+| 4 | Thread safety | Critical | Small |
+| 5 | WCAG contrast ratio | High | Small |
+| 6 | OKLCH support | High | Large |
+| 7 | Rounding accumulation | High | Medium |
+| 8 | Sendable conformance | High | Trivial |
+| 9 | Delta E API | Medium | Small |
+| 10 | Non-linear lightness curves | Medium | Medium |
+| 11 | Semantic token layer | Medium | Medium |
+| 12 | Error handling | Medium | Small |
+| 13 | Code dedup | Low | Small |
+| 14 | HSL/HSV/P3 | Low | Medium |
+| 15 | Color blindness sim | Low | Medium |
+| 16 | Documentation | Low | Medium |


### PR DESCRIPTION
## Summary

- Adds 48 tests across 4 new test files (up from 1 marketing asset test)
  - **ColorSpaceTests**: Reference value checks against CIE standards, round-trip accuracy through full conversion chain, alpha preservation, LCH string parsing
  - **InterpolationTests**: Lerp boundaries (0, 0.5, 1), shortest-path hue wrapping, opposite hues, alpha interpolation
  - **ColorRampTests**: Stop count, monotonic lightness, determinism, grayscale chroma, hue 0/360 equivalence, pro color validation
  - **UtilityTests**: normalizedHue edge cases, rounded precision, Double/CGFloat consistency
- Adds `docs/ROADMAP.md` with prioritized improvements from a codebase audit

## Test plan

- [x] `swift test` — 49 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)