### PR TITLE
Clamp RGB output to [0, 1] for out-of-gamut colors

### DIFF
--- a/Sources/ColorTokensKit/ColorSpace/XYZ/XYZColor+Conversions.swift
+++ b/Sources/ColorTokensKit/ColorSpace/XYZ/XYZColor+Conversions.swift
@@ -12,9 +12,9 @@ public extension XYZColor {
         let r = (x * 3.2404542) + (y * -1.5371385) + (z * -0.4985314)
         let g = (x * -0.9692660) + (y * 1.8760108) + (z * 0.0415560)
         let b = (x * 0.0556434) + (y * -0.2040259) + (z * 1.0572252)
-        let R = sRGBCompand(r)
-        let G = sRGBCompand(g)
-        let B = sRGBCompand(b)
+        let R = min(max(sRGBCompand(r), 0), 1)
+        let G = min(max(sRGBCompand(g), 0), 1)
+        let B = min(max(sRGBCompand(b), 0), 1)
         return RGBColor(r: R, g: G, b: B, alpha: alpha)
     }
 

--- a/Tests/ColorTokensKitTests/ColorSpaceTests.swift
+++ b/Tests/ColorTokensKitTests/ColorSpaceTests.swift
@@ -157,6 +157,29 @@ final class ColorSpaceConversionTests: XCTestCase {
         XCTAssertTrue(color.c > 100, "Red hex should have high chroma")
     }
 
+    // MARK: - Gamut Clamping
+
+    func testOutOfGamutLCHClampsRGBToValidRange() {
+        // Highly saturated LCH color that would produce out-of-gamut RGB
+        let outOfGamut = LCHColor(l: 50, c: 128, h: 270) // extreme blue-purple
+        let rgb = outOfGamut.toRGB()
+        XCTAssertGreaterThanOrEqual(rgb.r, 0, "R should be clamped >= 0, got \(rgb.r)")
+        XCTAssertLessThanOrEqual(rgb.r, 1, "R should be clamped <= 1, got \(rgb.r)")
+        XCTAssertGreaterThanOrEqual(rgb.g, 0, "G should be clamped >= 0, got \(rgb.g)")
+        XCTAssertLessThanOrEqual(rgb.g, 1, "G should be clamped <= 1, got \(rgb.g)")
+        XCTAssertGreaterThanOrEqual(rgb.b, 0, "B should be clamped >= 0, got \(rgb.b)")
+        XCTAssertLessThanOrEqual(rgb.b, 1, "B should be clamped <= 1, got \(rgb.b)")
+    }
+
+    func testInGamutColorUnaffectedByClamping() {
+        // A well-behaved mid-range color should round-trip without being clipped
+        let original = RGBColor(r: 0.5, g: 0.3, b: 0.7, alpha: 1)
+        let roundTrip = original.toLCH().toRGB()
+        XCTAssertEqual(roundTrip.r, original.r, accuracy: tolerance)
+        XCTAssertEqual(roundTrip.g, original.g, accuracy: tolerance)
+        XCTAssertEqual(roundTrip.b, original.b, accuracy: tolerance)
+    }
+
     func testLCHEquality() {
         let a = LCHColor(l: 50, c: 30, h: 180)
         let b = LCHColor(l: 50, c: 30, h: 180)


### PR DESCRIPTION
## Summary

- Clamps R, G, B values to [0, 1] in `XYZColor.toRGB()` — the single conversion path that can produce out-of-gamut values
- High-chroma LCH colors (e.g. saturated blue-purples) could previously produce negative or >1 RGB components, causing undefined rendering in SwiftUI/UIKit
- Adds 2 tests: one verifying clamping works on an extreme color, one verifying normal colors are unaffected

## Test plan

- [x] `swift test` — 51 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)