### PR TITLE
Shared ColorRampGenerator, thread-safe cache, Sendable conformance

### DIFF
--- a/Sources/ColorTokensKit/ColorSpace/LAB/LABColor.swift
+++ b/Sources/ColorTokensKit/ColorSpace/LAB/LABColor.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct LABColor: Hashable {
+public struct LABColor: Hashable, Sendable {
     public let l: CGFloat //    0..100
     public let a: CGFloat // -128..128
     public let b: CGFloat // -128..128

--- a/Sources/ColorTokensKit/ColorSpace/LCH/LCHColor+Manipulation.swift
+++ b/Sources/ColorTokensKit/ColorSpace/LCH/LCHColor+Manipulation.swift
@@ -26,9 +26,8 @@ public extension LCHColor {
 
     /// Gets a color at specified index in the ramp
     func getColor(at index: Int) -> LCHColor {
-        let rampGenerator = ColorRampGenerator()
         let isGrayscale = c <= 0.1
-        let ramp = rampGenerator.getColorRamp(forHue: h, isGrayscale: isGrayscale)
+        let ramp = ColorRampGenerator.shared.getColorRamp(forHue: h, isGrayscale: isGrayscale)
         let clampedIndex = min(index, ramp.count - 1)
         return ramp[clampedIndex]
     }
@@ -36,8 +35,7 @@ public extension LCHColor {
     /// Creates primary color for given hue
     static func getPrimaryColor(forHue hue: Double, isGrayscale: Bool = false) -> LCHColor {
         let steps = ColorConstants.rampStops
-        let rampGenerator = ColorRampGenerator()
-        let dataPoints = rampGenerator.getColorRamp(forHue: hue, steps: steps, isGrayscale: isGrayscale)
+        let dataPoints = ColorRampGenerator.shared.getColorRamp(forHue: hue, steps: steps, isGrayscale: isGrayscale)
         let primaryColor = dataPoints[Int(steps / 2) - 2]
 
         return LCHColor(

--- a/Sources/ColorTokensKit/ColorSpace/LCH/LCHColor.swift
+++ b/Sources/ColorTokensKit/ColorSpace/LCH/LCHColor.swift
@@ -7,7 +7,7 @@
 import Foundation
 import SwiftUI
 
-public struct LCHColor: Hashable, Equatable {
+public struct LCHColor: Hashable, Equatable, Sendable {
     public let l: CGFloat // 0..100. Lightness
     public let c: CGFloat // 0..128. Chroma
     public let h: CGFloat // 0..360. Hue

--- a/Sources/ColorTokensKit/ColorSpace/RGB/RGBColor.swift
+++ b/Sources/ColorTokensKit/ColorSpace/RGB/RGBColor.swift
@@ -7,7 +7,7 @@
 import Foundation
 import SwiftUI
 
-public struct RGBColor: Hashable {
+public struct RGBColor: Hashable, Sendable {
     public let r: CGFloat // 0..1
     public let g: CGFloat // 0..1
     public let b: CGFloat // 0..1

--- a/Sources/ColorTokensKit/ColorSpace/XYZ/XYZColor.swift
+++ b/Sources/ColorTokensKit/ColorSpace/XYZ/XYZColor.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public struct XYZColor: Hashable {
+public struct XYZColor: Hashable, Sendable {
     public let x: CGFloat // 0..0.95047
     public let y: CGFloat // 0..1
     public let z: CGFloat // 0..1.08883

--- a/Sources/ColorTokensKit/Services/Ramps/ColorRampGenerator.swift
+++ b/Sources/ColorTokensKit/Services/Ramps/ColorRampGenerator.swift
@@ -17,8 +17,11 @@
 import Foundation
 
 public class ColorRampGenerator {
-    // Make this static to share cache across instances
+    /// Shared instance to avoid redundant allocations
+    static let shared = ColorRampGenerator()
+
     private static var interpolatedRamps: [String: [LCHColor]] = [:]
+    private static let cacheLock = NSLock()
     private let colorPaletteData: ColorPaletteData
 
     /// Initializes the color ramp generator with required palette data
@@ -53,16 +56,21 @@ public class ColorRampGenerator {
         }()
 
         // Check static cache first
+        ColorRampGenerator.cacheLock.lock()
         if let cached = ColorRampGenerator.interpolatedRamps[cacheKey] {
+            ColorRampGenerator.cacheLock.unlock()
             return cached
         }
+        ColorRampGenerator.cacheLock.unlock()
 
         // If grayscale is requested, use the gray ramp from palette data
         if isGrayscale {
             let grayRamp = colorPaletteData.colorRamps.first { $0.name == "gray" }
             if let grayRamp = grayRamp {
                 let result = interpolateStops(from: grayRamp, to: grayRamp, t: 0)
+                ColorRampGenerator.cacheLock.lock()
                 ColorRampGenerator.interpolatedRamps[cacheKey] = result
+                ColorRampGenerator.cacheLock.unlock()
                 return result
             }
         }
@@ -90,7 +98,7 @@ public class ColorRampGenerator {
 
         // Calculate interpolation factor with proper wrapping
         let hueDiff = (normalizedUpperHue - normalizedLowerHue + 360).normalizedHue
-        
+
         // Calculate t with consistent precision
         let rawT = (normalizedTargetHue - normalizedLowerHue + 360).normalizedHue / hueDiff
         let t = rawT.rounded(to: ColorConstants.interpolationPrecision)
@@ -99,7 +107,9 @@ public class ColorRampGenerator {
         let result = interpolateStops(from: lowerRamp, to: upperRamp, t: t)
 
         // Cache in static dictionary
+        ColorRampGenerator.cacheLock.lock()
         ColorRampGenerator.interpolatedRamps[cacheKey] = result
+        ColorRampGenerator.cacheLock.unlock()
 
         return result
     }


### PR DESCRIPTION
## Summary

- **Performance**: Add `ColorRampGenerator.shared` singleton — previously `getColor(at:)` and `getPrimaryColor(forHue:)` created a new instance on every call (20 allocations per ramp query)
- **Thread safety**: Guard the static ramp cache with `NSLock` to prevent race conditions from concurrent access (e.g. SwiftUI background rendering)
- **Sendable**: Add `Sendable` conformance to `LCHColor`, `LABColor`, `XYZColor`, `RGBColor` — all immutable value types, enabling safe use with async/await

## Test plan

- [x] `swift test` — 51 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)