### PR TITLE
Add WCAG 2.x and APCA contrast ratio utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+docs/

--- a/Sources/ColorTokensKit/Accessibility/ContrastRatio.swift
+++ b/Sources/ColorTokensKit/Accessibility/ContrastRatio.swift
@@ -1,0 +1,107 @@
+//
+//  ContrastRatio.swift
+//  ColorTokensKit
+//
+
+import Foundation
+import SwiftUI
+
+/// Methods for computing color contrast
+public enum ContrastMethod {
+    /// WCAG 2.x luminance contrast ratio (range 1–21)
+    case wcag2
+    /// APCA (Accessible Perceptual Contrast Algorithm) as proposed for WCAG 3.0.
+    /// Returns a signed Lc value: positive = dark text on light background,
+    /// negative = light text on dark background. Typical threshold ~60 for body text.
+    case apca
+}
+
+public extension RGBColor {
+    /// Relative luminance per WCAG 2.x definition (0 = darkest, 1 = lightest)
+    var relativeLuminance: CGFloat {
+        func linearize(_ v: CGFloat) -> CGFloat {
+            return v <= 0.04045 ? v / 12.92 : pow((v + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
+    }
+
+    /// Contrast ratio between two colors using the specified method
+    func contrastRatio(to other: RGBColor, method: ContrastMethod = .wcag2) -> CGFloat {
+        switch method {
+        case .wcag2:
+            return wcag2ContrastRatio(to: other)
+        case .apca:
+            return apcaContrast(text: other)
+        }
+    }
+
+    // MARK: - WCAG 2.x
+
+    /// WCAG 2.x contrast ratio (1–21). Always returns the ratio with the lighter
+    /// color in the numerator, so the result is always >= 1.
+    private func wcag2ContrastRatio(to other: RGBColor) -> CGFloat {
+        let l1 = relativeLuminance
+        let l2 = other.relativeLuminance
+        let lighter = max(l1, l2)
+        let darker = min(l1, l2)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    // MARK: - APCA
+
+    /// APCA contrast value (Lc). `self` is the background, `other` is the text.
+    /// Positive Lc = dark text on light bg. Negative Lc = light text on dark bg.
+    /// Based on APCA-W3 0.0.98G-4g (Silver/WCAG 3.0 candidate).
+    private func apcaContrast(text: RGBColor) -> CGFloat {
+        // Estimated screen luminance using sRGB coefficients with APCA exponent
+        func screenLuminance(_ color: RGBColor) -> CGFloat {
+            let rLin = pow(color.r, 2.4)
+            let gLin = pow(color.g, 2.4)
+            let bLin = pow(color.b, 2.4)
+            return 0.2126729 * rLin + 0.7151522 * gLin + 0.0721750 * bLin
+        }
+
+        let bgY = screenLuminance(self)
+        let txtY = screenLuminance(text)
+
+        // Soft clamp near black
+        let bgYc = bgY > 0.022 ? bgY : bgY + pow(0.022 - bgY, 1.414)
+        let txtYc = txtY > 0.022 ? txtY : txtY + pow(0.022 - txtY, 1.414)
+
+        // SAPC (S-Luv Accessible Perceptual Contrast)
+        let contrast: CGFloat
+        if bgYc > txtYc {
+            // Light background, dark text (positive polarity)
+            contrast = (pow(bgYc, 0.56) - pow(txtYc, 0.57)) * 1.14
+        } else {
+            // Dark background, light text (negative polarity)
+            contrast = (pow(bgYc, 0.65) - pow(txtYc, 0.62)) * 1.14
+        }
+
+        // Low contrast clamp
+        if abs(contrast) < 0.1 {
+            return 0
+        }
+
+        // Scale to Lc value
+        if contrast > 0 {
+            return (contrast - 0.027) * 100
+        } else {
+            return (contrast + 0.027) * 100
+        }
+    }
+}
+
+public extension LCHColor {
+    /// Contrast ratio between two LCH colors
+    func contrastRatio(to other: LCHColor, method: ContrastMethod = .wcag2) -> CGFloat {
+        return toRGB().contrastRatio(to: other.toRGB(), method: method)
+    }
+}
+
+public extension Color {
+    /// Contrast ratio between two SwiftUI colors
+    func contrastRatio(to other: Color, method: ContrastMethod = .wcag2) -> CGFloat {
+        return toRGB().contrastRatio(to: other.toRGB(), method: method)
+    }
+}

--- a/Tests/ColorTokensKitTests/ContrastTests.swift
+++ b/Tests/ColorTokensKitTests/ContrastTests.swift
@@ -1,0 +1,113 @@
+@testable import ColorTokensKit
+import XCTest
+import SwiftUI
+
+final class ContrastTests: XCTestCase {
+
+    // MARK: - WCAG 2.x
+
+    func testBlackWhiteMaxContrast() {
+        let black = RGBColor(r: 0, g: 0, b: 0, alpha: 1)
+        let white = RGBColor(r: 1, g: 1, b: 1, alpha: 1)
+        let ratio = black.contrastRatio(to: white, method: .wcag2)
+        XCTAssertEqual(ratio, 21.0, accuracy: 0.05)
+    }
+
+    func testSameColorMinContrast() {
+        let gray = RGBColor(r: 0.5, g: 0.5, b: 0.5, alpha: 1)
+        let ratio = gray.contrastRatio(to: gray, method: .wcag2)
+        XCTAssertEqual(ratio, 1.0, accuracy: 0.01)
+    }
+
+    func testWCAGIsSymmetric() {
+        let a = RGBColor(r: 0.2, g: 0.4, b: 0.8, alpha: 1)
+        let b = RGBColor(r: 1, g: 1, b: 1, alpha: 1)
+        let ab = a.contrastRatio(to: b, method: .wcag2)
+        let ba = b.contrastRatio(to: a, method: .wcag2)
+        XCTAssertEqual(ab, ba, accuracy: 0.001, "WCAG contrast should be symmetric")
+    }
+
+    func testWCAGAlwaysAtLeastOne() {
+        let colors: [(CGFloat, CGFloat, CGFloat)] = [
+            (0.1, 0.1, 0.1), (0.5, 0.5, 0.5), (0.9, 0.9, 0.9),
+            (1, 0, 0), (0, 1, 0), (0, 0, 1),
+        ]
+        for (r, g, b) in colors {
+            let color = RGBColor(r: r, g: g, b: b, alpha: 1)
+            let white = RGBColor(r: 1, g: 1, b: 1, alpha: 1)
+            let ratio = color.contrastRatio(to: white, method: .wcag2)
+            XCTAssertGreaterThanOrEqual(ratio, 1.0)
+        }
+    }
+
+    func testWCAGKnownValue() {
+        // Pure blue (#0000FF) on white has a contrast ratio of ~8.59
+        let blue = RGBColor(r: 0, g: 0, b: 1, alpha: 1)
+        let white = RGBColor(r: 1, g: 1, b: 1, alpha: 1)
+        let ratio = blue.contrastRatio(to: white, method: .wcag2)
+        XCTAssertEqual(ratio, 8.59, accuracy: 0.1)
+    }
+
+    // MARK: - APCA
+
+    func testAPCABlackOnWhiteIsPositive() {
+        let white = RGBColor(r: 1, g: 1, b: 1, alpha: 1)
+        let black = RGBColor(r: 0, g: 0, b: 0, alpha: 1)
+        // Background is white, text is black → positive Lc (dark text on light bg)
+        let lc = white.contrastRatio(to: black, method: .apca)
+        XCTAssertGreaterThan(lc, 100, "Black on white should have high positive Lc, got \(lc)")
+    }
+
+    func testAPCAWhiteOnBlackIsNegative() {
+        let black = RGBColor(r: 0, g: 0, b: 0, alpha: 1)
+        let white = RGBColor(r: 1, g: 1, b: 1, alpha: 1)
+        // Background is black, text is white → negative Lc (light text on dark bg)
+        let lc = black.contrastRatio(to: white, method: .apca)
+        XCTAssertLessThan(lc, -100, "White on black should have high negative Lc, got \(lc)")
+    }
+
+    func testAPCASameColorIsZero() {
+        let gray = RGBColor(r: 0.5, g: 0.5, b: 0.5, alpha: 1)
+        let lc = gray.contrastRatio(to: gray, method: .apca)
+        XCTAssertEqual(lc, 0, accuracy: 1, "Same color should have near-zero APCA contrast")
+    }
+
+    func testAPCAIsAsymmetric() {
+        let white = RGBColor(r: 1, g: 1, b: 1, alpha: 1)
+        let darkGray = RGBColor(r: 0.2, g: 0.2, b: 0.2, alpha: 1)
+        let darkOnLight = white.contrastRatio(to: darkGray, method: .apca)
+        let lightOnDark = darkGray.contrastRatio(to: white, method: .apca)
+        // APCA is deliberately asymmetric — the magnitudes differ
+        XCTAssertNotEqual(abs(darkOnLight), abs(lightOnDark), accuracy: 1,
+            "APCA should be asymmetric: |\(darkOnLight)| vs |\(lightOnDark)|")
+    }
+
+    // MARK: - LCH and Color convenience
+
+    func testLCHContrastRatio() {
+        let light = LCHColor(l: 95, c: 0, h: 0)
+        let dark = LCHColor(l: 10, c: 0, h: 0)
+        let ratio = light.contrastRatio(to: dark, method: .wcag2)
+        XCTAssertGreaterThan(ratio, 10, "High lightness difference should produce high contrast")
+    }
+
+    func testDefaultMethodIsWCAG2() {
+        let a = RGBColor(r: 0, g: 0, b: 0, alpha: 1)
+        let b = RGBColor(r: 1, g: 1, b: 1, alpha: 1)
+        let defaultResult = a.contrastRatio(to: b)
+        let wcagResult = a.contrastRatio(to: b, method: .wcag2)
+        XCTAssertEqual(defaultResult, wcagResult, accuracy: 0.001)
+    }
+
+    // MARK: - Relative Luminance
+
+    func testRelativeLuminanceBlack() {
+        let black = RGBColor(r: 0, g: 0, b: 0, alpha: 1)
+        XCTAssertEqual(black.relativeLuminance, 0, accuracy: 0.001)
+    }
+
+    func testRelativeLuminanceWhite() {
+        let white = RGBColor(r: 1, g: 1, b: 1, alpha: 1)
+        XCTAssertEqual(white.relativeLuminance, 1, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `contrastRatio(to:method:)` on `RGBColor`, `LCHColor`, and `Color`
- Two methods via `ContrastMethod` enum:
  - `.wcag2` (default) — standard luminance contrast ratio (1–21), symmetric
  - `.apca` — APCA-W3 perceptual contrast for WCAG 3.0, returns signed Lc value accounting for text polarity (dark-on-light vs light-on-dark)
- Exposes `relativeLuminance` on `RGBColor`
- Adds `docs/` to `.gitignore` for local planning docs
- 13 new tests covering both algorithms, symmetry/asymmetry, known values, edge cases

## Test plan

- [x] `swift test` — 64 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)